### PR TITLE
docs(en2zh): fix typo

### DIFF
--- a/.github/ISSUE_TEMPLATE/en2zh.yml
+++ b/.github/ISSUE_TEMPLATE/en2zh.yml
@@ -7,7 +7,7 @@ body:
     id: duplicate-check
     attributes:
       label: 检查重复提议
-      description: 前往 [Issues 列表](https://github.com/re0wiki/wiki-bot/issues?q=is%3Aissue) 搜索新译名，若已被提出过则直接前往讨论，不必新建 Issue。
+      description: 前往 [Issues 列表](https://github.com/re0wiki/wiki-bot/issues?q=is%3Aissue) 搜索译名，若已被提出过则直接前往讨论，不必新建 Issue。
       options:
         - label: 该译名未被提出过
   - type: textarea


### PR DESCRIPTION
在没有旧译名的情况下不需要称为新译名